### PR TITLE
avoid notify the same block that reaches consensus at the first period

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #------------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.3" CACHE STRING "Minimum OS X deployment version")
 
 if (NOT DEFINED URL_BASE)
     set(URL_BASE "github.com")

--- a/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -71,7 +71,7 @@ void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig)
         m_syncingState = false;
         m_timer->start();
     }
-    notifySealer(progressedIndex());
+    notifySealer(m_expectedCheckPoint);
     if (!m_blockSync)
     {
         return;

--- a/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -331,7 +331,7 @@ CheckResult PBFTEngine::checkPBFTMsgState(PBFTMessageInterface::Ptr _pbftReq) co
     {
         return CheckResult::INVALID;
     }
-    if (_pbftReq->index() < m_config->progressedIndex() ||
+    if (_pbftReq->index() < m_config->expectedCheckPoint() ||
         _pbftReq->index() >= m_config->highWaterMark())
     {
         PBFT_LOG(TRACE) << LOG_DESC("checkPBFTMsgState: invalid pbftMsg for invalid index")

--- a/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -21,10 +21,10 @@
 #include "PBFTEngine.h"
 #include "../cache/PBFTCacheFactory.h"
 #include "../cache/PBFTCacheProcessor.h"
-#include "boost/bind.hpp"
 #include <bcos-framework/interfaces/ledger/LedgerConfig.h>
 #include <bcos-framework/interfaces/protocol/Protocol.h>
 #include <bcos-framework/libutilities/ThreadPool.h>
+#include <boost/bind/bind.hpp>
 using namespace bcos;
 using namespace bcos::consensus;
 using namespace bcos::ledger;
@@ -44,9 +44,9 @@ PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config)
     // register the timeout function
     m_config->timer()->registerTimeoutHandler(boost::bind(&PBFTEngine::onTimeout, this));
     m_config->storage()->registerFinalizeHandler(
-        boost::bind(&PBFTEngine::finalizeConsensus, this, _1));
+        boost::bind(&PBFTEngine::finalizeConsensus, this, boost::placeholders::_1));
     m_cacheProcessor->registerProposalAppliedHandler(
-        boost::bind(&PBFTEngine::onProposalApplied, this, _1));
+        boost::bind(&PBFTEngine::onProposalApplied, this, boost::placeholders::_1));
 }
 
 void PBFTEngine::start()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,4 +1,4 @@
 hunter_config(bcos-framework VERSION 3.0.0-local
-    URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/98a2530574ebf546fe38f92bddf3fe33305d9057.tar.gz"
-    SHA1 be626ecd549151564dcec75cd4f2b2579188c237
+    URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/fd7ee8e867e5c9dc6254b17d05954afacdeea564.tar.gz"
+    SHA1 be2cd17cfeafcabc6caee49fef9fa1ab336fa066
 )

--- a/test/unittests/pbft/PBFTConfigTest.cpp
+++ b/test/unittests/pbft/PBFTConfigTest.cpp
@@ -151,8 +151,8 @@ BOOST_AUTO_TEST_CASE(testPBFTInit)
     pbftConfig->storage()->asyncCommitProposal(fakedProposal);
     faker->init();
     BOOST_CHECK(pbftConfig->minRequiredQuorum() == 1);
-    while (faker->ledger()->blockNumber() != proposalIndex ||
-           (pbftConfig->progressedIndex() != proposalIndex + 1))
+    auto startT = utcTime();
+    while (faker->ledger()->blockNumber() != proposalIndex && (utcTime() - startT <= 60 * 1000))
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }


### PR DESCRIPTION
1. avoid notify the same block that reaches consensus at the first period
2. When the PBFT has not been initialized, it is not allowed to call related interfaces