### PR TITLE
clear all the future proposals when receive the synced block notification 

### DIFF
--- a/bcos-pbft/pbft/PBFTImpl.cpp
+++ b/bcos-pbft/pbft/PBFTImpl.cpp
@@ -51,31 +51,12 @@ void PBFTImpl::asyncSubmitProposal(bytesConstRef _proposalData,
     bcos::protocol::BlockNumber _proposalIndex, bcos::crypto::HashType const& _proposalHash,
     std::function<void(Error::Ptr)> _onProposalSubmitted)
 {
-    if (!m_running)
-    {
-        if (_onProposalSubmitted)
-        {
-            _onProposalSubmitted(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"));
-        }
-        return;
-    }
     return m_pbftEngine->asyncSubmitProposal(
         _proposalData, _proposalIndex, _proposalHash, _onProposalSubmitted);
 }
 
 void PBFTImpl::asyncGetPBFTView(std::function<void(Error::Ptr, ViewType)> _onGetView)
 {
-    if (!m_running)
-    {
-        if (_onGetView)
-        {
-            _onGetView(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"),
-                0);
-        }
-        return;
-    }
     auto view = m_pbftEngine->pbftConfig()->view();
     if (!_onGetView)
     {
@@ -88,15 +69,6 @@ void PBFTImpl::asyncNotifyConsensusMessage(bcos::Error::Ptr _error, std::string 
     bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
     std::function<void(Error::Ptr _error)> _onRecv)
 {
-    if (!m_running)
-    {
-        if (_onRecv)
-        {
-            _onRecv(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"));
-        }
-        return;
-    }
     m_pbftEngine->onReceivePBFTMessage(_error, _id, _nodeID, _data);
     if (!_onRecv)
     {
@@ -109,16 +81,6 @@ void PBFTImpl::asyncNotifyConsensusMessage(bcos::Error::Ptr _error, std::string 
 void PBFTImpl::asyncCheckBlock(
     bcos::protocol::Block::Ptr _block, std::function<void(Error::Ptr, bool)> _onVerifyFinish)
 {
-    if (!m_running)
-    {
-        if (_onVerifyFinish)
-        {
-            _onVerifyFinish(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"),
-                false);
-        }
-        return;
-    }
     m_blockValidator->asyncCheckBlock(_block, _onVerifyFinish);
 }
 
@@ -126,16 +88,6 @@ void PBFTImpl::asyncCheckBlock(
 void PBFTImpl::asyncNotifyNewBlock(
     bcos::ledger::LedgerConfig::Ptr _ledgerConfig, std::function<void(Error::Ptr)> _onRecv)
 {
-    if (!m_running)
-    {
-        if (_onRecv)
-        {
-            _onRecv(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"));
-        }
-        return;
-    }
-
     m_pbftEngine->asyncNotifyNewBlock(_ledgerConfig, _onRecv);
 }
 
@@ -147,15 +99,6 @@ void PBFTImpl::notifyHighestSyncingNumber(bcos::protocol::BlockNumber _blockNumb
 void PBFTImpl::asyncNoteUnSealedTxsSize(
     size_t _unsealedTxsSize, std::function<void(Error::Ptr)> _onRecvResponse)
 {
-    if (!m_running)
-    {
-        if (_onRecvResponse)
-        {
-            _onRecvResponse(
-                std::make_shared<Error>(-1, "The PBFT module has not been initialized finished!"));
-        }
-        return;
-    }
     m_pbftEngine->pbftConfig()->setUnSealedTxsSize(_unsealedTxsSize);
     if (_onRecvResponse)
     {

--- a/bcos-pbft/pbft/PBFTImpl.cpp
+++ b/bcos-pbft/pbft/PBFTImpl.cpp
@@ -132,8 +132,6 @@ void PBFTImpl::init()
     {
         PBFT_LOG(INFO) << LOG_DESC("init PBFT state")
                        << LOG_KV("stateProposals", stateProposals->size());
-        auto consensusedProposalIndex = config->storage()->maxCommittedProposalIndex();
-        config->setProgressedIndex(consensusedProposalIndex + 1);
         m_pbftEngine->initState(*stateProposals);
     }
     config->timer()->start();

--- a/bcos-pbft/pbft/PBFTImpl.h
+++ b/bcos-pbft/pbft/PBFTImpl.h
@@ -90,6 +90,13 @@ public:
         m_pbftEngine->pbftConfig()->registerNewBlockNotifier(_newBlockNotifier);
     }
 
+    void registerCommittedProposalNotifier(
+        std::function<void(bcos::protocol::BlockNumber, std::function<void(Error::Ptr)>)>
+            _committedProposalNotifier)
+    {
+        m_pbftEngine->registerCommittedProposalNotifier(_committedProposalNotifier);
+    }
+
 protected:
     PBFTEngine::Ptr m_pbftEngine;
     BlockValidator::Ptr m_blockValidator;

--- a/bcos-pbft/pbft/PBFTImpl.h
+++ b/bcos-pbft/pbft/PBFTImpl.h
@@ -90,6 +90,7 @@ public:
         m_pbftEngine->pbftConfig()->registerNewBlockNotifier(_newBlockNotifier);
     }
 
+    // handler to notify the consensusing prosal index to the sync module
     void registerCommittedProposalNotifier(
         std::function<void(bcos::protocol::BlockNumber, std::function<void(Error::Ptr)>)>
             _committedProposalNotifier)

--- a/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -206,6 +206,20 @@ void PBFTCacheProcessor::updateCommitQueue(PBFTProposalInterface::Ptr _committed
     m_committedProposalList.insert(_committedProposal->index());
     PBFT_LOG(INFO) << LOG_DESC("######## CommitProposal") << printPBFTProposal(_committedProposal)
                    << m_config->printCurrentState();
+    if (m_committedProposalNotifier)
+    {
+        m_committedProposalNotifier(
+            _committedProposal->index(), [_committedProposal](Error::Ptr _error) {
+                if (!_error)
+                {
+                    return;
+                }
+                PBFT_LOG(WARNING)
+                    << LOG_DESC("notify the committed proposal index to the sync module failed")
+                    << LOG_KV("index", _committedProposal->index())
+                    << LOG_KV("hash", _committedProposal->hash().abridged());
+            });
+    }
     tryToApplyCommitQueue();
 }
 

--- a/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
+++ b/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
@@ -136,6 +136,12 @@ public:
         m_proposalAppliedHandler = _callback;
     }
 
+    void registerCommittedProposalNotifier(
+        std::function<void(bcos::protocol::BlockNumber, std::function<void(Error::Ptr)>)>
+            _committedProposalNotifier)
+    {
+        m_committedProposalNotifier = _committedProposalNotifier;
+    }
     void tryToApplyCommitQueue();
 
 protected:
@@ -188,6 +194,8 @@ protected:
         m_stableCheckPointQueue;
 
     std::function<void(PBFTProposalInterface::Ptr)> m_proposalAppliedHandler;
+    std::function<void(bcos::protocol::BlockNumber, std::function<void(Error::Ptr)>)>
+        m_committedProposalNotifier;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
+++ b/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
@@ -144,6 +144,10 @@ public:
     }
     void tryToApplyCommitQueue();
 
+    void removeFutureProposals();
+    // notify the consensusing proposal index to the sync module
+    void notifyCommittedProposalIndex(bcos::protocol::BlockNumber _index);
+
 protected:
     virtual void loadAndVerifyProposal(
         bcos::crypto::NodeIDPtr _fromNode, PBFTProposalInterface::Ptr _proposal);

--- a/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -74,9 +74,13 @@ void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig)
     if (m_syncingState)
     {
         m_syncingState = false;
+        m_timeoutState = true;
         m_timer->start();
     }
-    notifySealer(m_expectedCheckPoint);
+    if (!m_timeoutState)
+    {
+        notifySealer(m_expectedCheckPoint);
+    }
     if (!m_newBlockNotifier)
     {
         return;

--- a/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -25,7 +25,7 @@ using namespace bcos::consensus;
 using namespace bcos::protocol;
 using namespace bcos::ledger;
 
-void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig)
+void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
 {
     PBFT_LOG(INFO) << LOG_DESC("resetConfig")
                    << LOG_KV("committedIndex", _ledgerConfig->blockNumber())
@@ -64,37 +64,39 @@ void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig)
     {
         m_stateNotifier(_ledgerConfig->blockNumber());
     }
+    // notify the latest block to the sync module
+    if (m_newBlockNotifier && !_syncedBlock)
+    {
+        m_newBlockNotifier(_ledgerConfig, [_ledgerConfig](Error::Ptr _error) {
+            if (_error)
+            {
+                PBFT_LOG(WARNING) << LOG_DESC("asyncNotifyNewBlock to sync module failed")
+                                  << LOG_KV("number", _ledgerConfig->blockNumber())
+                                  << LOG_KV("hash", _ledgerConfig->hash().abridged())
+                                  << LOG_KV("code", _error->errorCode())
+                                  << LOG_KV("msg", _error->errorMessage());
+            }
+        });
+    }
 
+    // the node is syncing, reset the timeout state to false for view recovery
     if (m_syncingHighestNumber > _ledgerConfig->blockNumber())
     {
+        m_timeoutState = true;
         m_syncingState = true;
         return;
     }
-    // try to reach a new view after syncing completed
+    // after syncing finished, try to reach a new view after syncing completed
     if (m_syncingState)
     {
         m_syncingState = false;
-        m_timeoutState = true;
         m_timer->start();
     }
+    // try to notify the sealer module to seal proposals
     if (!m_timeoutState)
     {
         notifySealer(m_expectedCheckPoint);
     }
-    if (!m_newBlockNotifier)
-    {
-        return;
-    }
-    m_newBlockNotifier(_ledgerConfig, [_ledgerConfig](Error::Ptr _error) {
-        if (_error)
-        {
-            PBFT_LOG(WARNING) << LOG_DESC("asyncNotifyNewBlock to sync module failed")
-                              << LOG_KV("number", _ledgerConfig->blockNumber())
-                              << LOG_KV("hash", _ledgerConfig->hash().abridged())
-                              << LOG_KV("code", _error->errorCode())
-                              << LOG_KV("msg", _error->errorMessage());
-        }
-    });
 }
 
 void PBFTConfig::notifySealer(BlockNumber _progressedIndex, bool _enforce)

--- a/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -137,7 +137,8 @@ protected:
     virtual bool handleCheckPointMsg(std::shared_ptr<PBFTMessageInterface> _checkPointMsg);
 
     // function called after reaching a consensus
-    virtual void finalizeConsensus(std::shared_ptr<bcos::ledger::LedgerConfig> _ledgerConfig);
+    virtual void finalizeConsensus(
+        std::shared_ptr<bcos::ledger::LedgerConfig> _ledgerConfig, bool _syncedBlock = false);
 
     virtual void onProposalApplied(PBFTProposalInterface::Ptr _executedProposal);
 

--- a/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -79,6 +79,12 @@ public:
 
     virtual std::shared_ptr<PBFTCacheProcessor> cacheProcessor() { return m_cacheProcessor; }
     virtual bool isTimeout() { return m_config->timeout(); }
+    void registerCommittedProposalNotifier(
+        std::function<void(bcos::protocol::BlockNumber, std::function<void(Error::Ptr)>)>
+            _committedProposalNotifier)
+    {
+        m_cacheProcessor->registerCommittedProposalNotifier(_committedProposalNotifier);
+    }
 
 protected:
     virtual void initSendResponseHandler();

--- a/bcos-pbft/pbft/interfaces/PBFTStorage.h
+++ b/bcos-pbft/pbft/interfaces/PBFTStorage.h
@@ -40,6 +40,7 @@ public:
     virtual int64_t maxCommittedProposalIndex() = 0;
     virtual void asyncCommitProposal(PBFTProposalInterface::Ptr _commitProposal) = 0;
     virtual void asyncCommmitStableCheckPoint(PBFTProposalInterface::Ptr _stableProposal) = 0;
+    virtual void asyncRemoveStabledCheckPoint(size_t _stabledCheckPointIndex) = 0;
 
     // get the latest committed proposal from the storage
     virtual void asyncGetCommittedProposals(bcos::protocol::BlockNumber _start, size_t _offset,
@@ -48,7 +49,7 @@ public:
         std::function<void(bcos::ledger::LedgerConfig::Ptr)> _resetConfigHandler) = 0;
 
     virtual void registerFinalizeHandler(
-        std::function<void(bcos::ledger::LedgerConfig::Ptr)> _finalizeHandler) = 0;
+        std::function<void(bcos::ledger::LedgerConfig::Ptr, bool)> _finalizeHandler) = 0;
     virtual void registerNotifyHandler(
         std::function<void(bcos::protocol::Block::Ptr, bcos::protocol::BlockHeader::Ptr)>
             _notifyHandler) = 0;

--- a/bcos-pbft/pbft/storage/LedgerStorage.cpp
+++ b/bcos-pbft/pbft/storage/LedgerStorage.cpp
@@ -346,7 +346,7 @@ void LedgerStorage::asyncCommitStableCheckPoint(
                 // finalize consensus
                 if (ledgerStorage->m_finalizeHandler)
                 {
-                    ledgerStorage->m_finalizeHandler(_ledgerConfig);
+                    ledgerStorage->m_finalizeHandler(_ledgerConfig, false);
                 }
                 // notify txpool the result
                 if (ledgerStorage->m_notifyHandler)

--- a/bcos-pbft/pbft/storage/LedgerStorage.h
+++ b/bcos-pbft/pbft/storage/LedgerStorage.h
@@ -55,7 +55,8 @@ public:
     }
 
     void registerFinalizeHandler(
-        std::function<void(bcos::ledger::LedgerConfig::Ptr)> _finalizeHandler) override
+        std::function<void(bcos::ledger::LedgerConfig::Ptr, bool _syncBlock)> _finalizeHandler)
+        override
     {
         m_finalizeHandler = _finalizeHandler;
     }
@@ -72,13 +73,14 @@ public:
 
     int64_t maxCommittedProposalIndex() override { return m_maxCommittedProposalIndex; }
 
+    void asyncRemoveStabledCheckPoint(size_t _stabledCheckPointIndex) override;
+
 protected:
     virtual void asyncPutProposal(std::string const& _dbName, std::string const& _key,
         bytesPointer _committedData, bcos::protocol::BlockNumber _proposalIndex,
         size_t _retryTime = 0);
 
     virtual void asyncRemove(std::string const& _dbName, std::string const& _key);
-    virtual void asyncRemoveStabledCheckPoint(size_t _stabledCheckPointIndex);
 
     virtual void asyncCommitStableCheckPoint(
         bcos::protocol::BlockHeader::Ptr _blockHeader, bcos::protocol::Block::Ptr _blockInfo);
@@ -104,7 +106,7 @@ protected:
     boost::mutex x_signalled;
 
     std::function<void(bcos::ledger::LedgerConfig::Ptr)> m_resetConfigHandler;
-    std::function<void(bcos::ledger::LedgerConfig::Ptr)> m_finalizeHandler;
+    std::function<void(bcos::ledger::LedgerConfig::Ptr, bool _syncBlock)> m_finalizeHandler;
 
     std::function<void(bcos::protocol::Block::Ptr, bcos::protocol::BlockHeader::Ptr)>
         m_notifyHandler;

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,4 +1,4 @@
 hunter_config(bcos-framework VERSION 3.0.0-local
-    URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/e2193a04b6f5d6299839dc465b1e679802eb3675.tar.gz"
-    SHA1 d1075dc7c3645dc9191b39d3931e8bd096a93fd4
+    URL "https://${URL_BASE}/cyjseagull/bcos-framework/archive/04945e79b0158caa9f4d2cd3778289d762eb5854.tar.gz"
+    SHA1 03d709e56e408c873393e0efd9bc1cde58e0e9f5
 )

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,4 +1,4 @@
 hunter_config(bcos-framework VERSION 3.0.0-local
-    URL "https://${URL_BASE}/cyjseagull/bcos-framework/archive/04945e79b0158caa9f4d2cd3778289d762eb5854.tar.gz"
-    SHA1 03d709e56e408c873393e0efd9bc1cde58e0e9f5
+    URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/a53669c898e6da02037db64406bab1edbb65a4a6.tar.gz"
+    SHA1 ed67745ffc205bb2c19f7819713702d744a27d72
 )

--- a/test/unittests/pbft/PBFTFixture.h
+++ b/test/unittests/pbft/PBFTFixture.h
@@ -210,6 +210,8 @@ public:
         auto fakedPBFT = std::make_shared<FakePBFTImpl>(pbftEngine);
         auto ledgerFetcher = std::make_shared<bcos::tool::LedgerConfigFetcher>(m_ledger);
         fakedPBFT->setLedgerFetcher(ledgerFetcher);
+        pbftConfig->setTimeoutState(false);
+        pbftConfig->timer()->stop();
         return fakedPBFT;
     }
 };


### PR DESCRIPTION
1. the pbft notify the committed proposal index to the sync in case of duplicated execution
2. clear all the future proposals when receive the synced block notification in case of inconsistent parentHash