### PR TITLE
 fix seal new block caused sync exception when reHandle the proposals with system transactions

### DIFF
--- a/bcos-pbft/core/ConsensusConfig.cpp
+++ b/bcos-pbft/core/ConsensusConfig.cpp
@@ -103,11 +103,6 @@ void ConsensusConfig::setConsensusNodeList(ConsensusNodeList& _consensusNodeList
     }
     // update quorum
     updateQuorum();
-    if (committedProposal())
-    {
-        auto proposalIndex = committedProposal()->index() + 1;
-        notifyResetSealing(proposalIndex);
-    }
     CONSENSUS_LOG(INFO) << LOG_DESC("updateConsensusNodeList")
                         << LOG_KV("nodeNum", m_consensusNodeNum) << LOG_KV("nodeIndex", nodeIndex)
                         << LOG_KV("committedIndex",

--- a/bcos-pbft/core/ConsensusConfig.h
+++ b/bcos-pbft/core/ConsensusConfig.h
@@ -98,8 +98,6 @@ public:
         m_blockTxCountLimit = _blockTxCountLimit;
     }
     virtual uint64_t blockTxCountLimit() const { return m_blockTxCountLimit.load(); }
-    virtual void notifyResetSealing(bcos::protocol::BlockNumber _consIndex) = 0;
-
     bcos::protocol::BlockNumber syncingHighestNumber() const { return m_syncingHighestNumber; }
     void setSyncingHighestNumber(bcos::protocol::BlockNumber _number)
     {

--- a/bcos-pbft/pbft/cache/PBFTCache.h
+++ b/bcos-pbft/pbft/cache/PBFTCache.h
@@ -66,6 +66,7 @@ public:
         }
         m_prePrepare = _prePrepareMsg;
         PBFT_LOG(INFO) << LOG_DESC("addPrePrepareCache") << printPBFTMsgInfo(_prePrepareMsg)
+                       << LOG_KV("sys", _prePrepareMsg->consensusProposal()->systemProposal())
                        << m_config->printCurrentState();
     }
 

--- a/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
+++ b/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
@@ -207,6 +207,8 @@ protected:
     void reCalculateViewChangeWeight();
     void removeInvalidRecoverCache(ViewType _view);
 
+    virtual void notifyToSealNextBlock(PBFTProposalInterface::Ptr _checkpointProposal);
+
 protected:
     PBFTCacheFactory::Ptr m_cacheFactory;
     PBFTConfig::Ptr m_config;
@@ -243,6 +245,8 @@ protected:
     // the recover message cache
     std::map<ViewType, std::map<IndexType, PBFTMessageInterface::Ptr>> m_recoverReqCache;
     std::map<ViewType, uint64_t> m_recoverCacheWeight;
+
+    bcos::protocol::BlockNumber m_maxNotifyIndex = 0;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -111,7 +111,23 @@ void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
     // try to notify the sealer module to seal proposals
     if (!m_timeoutState)
     {
-        notifySealer(m_expectedCheckPoint);
+        if (m_waitResealUntil == _ledgerConfig->blockNumber())
+        {
+            auto notifyBeginIndex = std::max(sealStartIndex(), m_waitResealUntil + 1);
+            PBFT_LOG(INFO) << LOG_DESC("Reach reseal index")
+                           << LOG_KV("notifyBeginIndex", notifyBeginIndex) << printCurrentState();
+            reNotifySealer(notifyBeginIndex);
+        }
+        if (m_waitSealUntil > _ledgerConfig->blockNumber())
+        {
+            PBFT_LOG(INFO) << LOG_DESC(
+                                  "Not notify the sealer to sealing for not reach waitToSeal limit")
+                           << LOG_KV("sealUntil", m_waitSealUntil) << printCurrentState();
+        }
+        else
+        {
+            notifySealer(sealStartIndex());
+        }
     }
 }
 
@@ -123,7 +139,8 @@ void PBFTConfig::notifyResetSealing(std::function<void()> _callback)
     }
     // only notify the non-leader to reset sealing
     PBFT_LOG(INFO) << LOG_DESC("notifyResetSealing") << printCurrentState();
-    m_sealerResetNotifier([this, _callback](Error::Ptr _error) {
+    auto committedIndex = m_committedProposal->index();
+    m_sealerResetNotifier([this, _callback, committedIndex](Error::Ptr _error) {
         if (_error)
         {
             PBFT_LOG(INFO) << LOG_DESC("notifyResetSealing failed")
@@ -131,7 +148,7 @@ void PBFTConfig::notifyResetSealing(std::function<void()> _callback)
                            << LOG_KV("msg", _error->errorMessage()) << printCurrentState();
             return;
         }
-        if (_callback)
+        if (_callback && m_waitResealUntil <= committedIndex)
         {
             _callback();
         }
@@ -146,6 +163,13 @@ void PBFTConfig::reNotifySealer(bcos::protocol::BlockNumber _index)
         PBFT_LOG(INFO) << LOG_DESC("reNotifySealer return for invalid expectedStart")
                        << LOG_KV("expectedStart", _index)
                        << LOG_KV("highWaterMark", highWaterMark()) << printCurrentState();
+        return;
+    }
+    auto committedIndex = m_committedProposal->index();
+    if (m_waitSealUntil > committedIndex)
+    {
+        PBFT_LOG(INFO) << LOG_DESC("reNotifySealer return for not reach waitToSeal limit")
+                       << LOG_KV("sealUntil", m_waitSealUntil) << printCurrentState();
         return;
     }
     PBFT_LOG(INFO) << LOG_DESC("reNotifySealer") << LOG_KV("expectedStart", _index)

--- a/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -27,6 +27,15 @@ using namespace bcos::ledger;
 
 void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
 {
+    bcos::protocol::BlockNumber committedIndex = 0;
+    if (m_committedProposal)
+    {
+        committedIndex = m_committedProposal->index();
+    }
+    if (_ledgerConfig->blockNumber() <= committedIndex && committedIndex > 0)
+    {
+        return;
+    }
     PBFT_LOG(INFO) << LOG_DESC("resetConfig")
                    << LOG_KV("committedIndex", _ledgerConfig->blockNumber())
                    << LOG_KV("propHash", _ledgerConfig->hash().abridged())

--- a/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -317,16 +317,16 @@ void PBFTEngine::resetSealedTxs(std::shared_ptr<PBFTMessageInterface> _prePrepar
 void PBFTEngine::asyncNotifyNewBlock(
     LedgerConfig::Ptr _ledgerConfig, std::function<void(Error::Ptr)> _onRecv)
 {
-    if (_onRecv)
-    {
-        _onRecv(nullptr);
-    }
     if (m_config->shouldResetConfig(_ledgerConfig->blockNumber()))
     {
         PBFT_LOG(INFO) << LOG_DESC("The sync module notify the latestBlock")
                        << LOG_KV("index", _ledgerConfig->blockNumber())
                        << LOG_KV("hash", _ledgerConfig->hash().abridged());
         finalizeConsensus(_ledgerConfig, true);
+    }
+    if (_onRecv)
+    {
+        _onRecv(nullptr);
     }
 }
 

--- a/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -266,7 +266,7 @@ void PBFTEngine::onRecvProposal(bool _containSysTxs, bytesConstRef _proposalData
         PBFT_LOG(INFO) << LOG_DESC("onRecvProposal failed for timout now")
                        << LOG_KV("index", _proposalIndex)
                        << LOG_KV("hash", _proposalHash.abridged()) << m_config->printCurrentState();
-        m_config->notifyResetSealing(m_config->committedProposal()->index() + 1);
+        m_config->notifyResetSealing();
         m_config->validator()->asyncResetTxsFlag(_proposalData, false);
         return;
     }
@@ -283,12 +283,6 @@ void PBFTEngine::onRecvProposal(bool _containSysTxs, bytesConstRef _proposalData
     auto pbftMessage =
         m_config->pbftMessageFactory()->populateFrom(PacketType::PrePreparePacket, pbftProposal,
             m_config->pbftMsgDefaultVersion(), m_config->view(), utcTime(), m_config->nodeIndex());
-
-    // broadcast the pre-prepare packet
-    auto encodedData = m_config->codec()->encode(pbftMessage);
-    m_config->frontService()->asyncSendMessageByNodeIDs(
-        ModuleID::PBFT, m_config->consensusNodeIDList(), ref(*encodedData));
-
     PBFT_LOG(INFO) << LOG_DESC("++++++++++++++++ Generating seal on")
                    << LOG_KV("index", pbftMessage->index()) << LOG_KV("Idx", m_config->nodeIndex())
                    << LOG_KV("hash", pbftMessage->hash().abridged())
@@ -297,7 +291,15 @@ void PBFTEngine::onRecvProposal(bool _containSysTxs, bytesConstRef _proposalData
     // handle the pre-prepare packet
     Guard l(m_mutex);
     auto ret = handlePrePrepareMsg(pbftMessage, false, false, false);
-    if (!ret)
+    // only broadcast the prePrepareMsg when local handlePrePrepareMsg success
+    if (ret)
+    {
+        // broadcast the pre-prepare packet
+        auto encodedData = m_config->codec()->encode(pbftMessage);
+        m_config->frontService()->asyncSendMessageByNodeIDs(
+            ModuleID::PBFT, m_config->consensusNodeIDList(), ref(*encodedData));
+    }
+    else
     {
         resetSealedTxs(pbftMessage);
     }
@@ -309,7 +311,7 @@ void PBFTEngine::resetSealedTxs(std::shared_ptr<PBFTMessageInterface> _prePrepar
     {
         return;
     }
-    m_config->notifyResetSealing(m_config->committedProposal()->index() + 1);
+    m_config->notifyResetSealing();
     m_config->validator()->asyncResetTxsFlag(_prePrepareMsg->consensusProposal()->data(), false);
 }
 
@@ -317,16 +319,16 @@ void PBFTEngine::resetSealedTxs(std::shared_ptr<PBFTMessageInterface> _prePrepar
 void PBFTEngine::asyncNotifyNewBlock(
     LedgerConfig::Ptr _ledgerConfig, std::function<void(Error::Ptr)> _onRecv)
 {
+    if (_onRecv)
+    {
+        _onRecv(nullptr);
+    }
     if (m_config->shouldResetConfig(_ledgerConfig->blockNumber()))
     {
         PBFT_LOG(INFO) << LOG_DESC("The sync module notify the latestBlock")
                        << LOG_KV("index", _ledgerConfig->blockNumber())
                        << LOG_KV("hash", _ledgerConfig->hash().abridged());
         finalizeConsensus(_ledgerConfig, true);
-    }
-    if (_onRecv)
-    {
-        _onRecv(nullptr);
     }
 }
 
@@ -438,7 +440,7 @@ void PBFTEngine::executeWorker()
         return;
     }
     // when the node is syncing, not handle the PBFT message
-    if (m_config->committedProposal()->index() < m_config->syncingHighestNumber())
+    if (isSyncingHigher())
     {
         waitSignal();
         return;
@@ -582,6 +584,11 @@ CheckResult PBFTEngine::checkPrePrepareMsg(std::shared_ptr<PBFTMessageInterface>
                         << m_config->printCurrentState();
         return CheckResult::INVALID;
     }
+    // already has prePrepare msg
+    if (m_cacheProcessor->conflictWithProcessedReq(_prePrepareMsg))
+    {
+        return CheckResult::INVALID;
+    }
     // check conflict
     if (m_cacheProcessor->conflictWithPrecommitReq(_prePrepareMsg))
     {
@@ -630,10 +637,21 @@ bool PBFTEngine::checkProposalSignature(
         nodeInfo->nodeID(), _proposal->hash(), _proposal->signature());
 }
 
+bool PBFTEngine::isSyncingHigher()
+{
+    auto committedIndex = m_config->committedProposal()->index();
+    auto syncNumber = m_config->syncingHighestNumber();
+    if (syncNumber < (committedIndex + m_config->warterMarkLimit()))
+    {
+        return false;
+    }
+    return true;
+}
+
 bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
     bool _needVerifyProposal, bool _generatedFromNewView, bool _needCheckSignature)
 {
-    if (m_config->committedProposal()->index() < m_config->syncingHighestNumber())
+    if (isSyncingHigher())
     {
         PBFT_LOG(INFO)
             << LOG_DESC("handlePrePrepareMsg: reject the prePrepareMsg for the node is syncing")
@@ -695,16 +713,6 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
         // add the pre-prepare packet into the cache
         m_cacheProcessor->addPrePrepareCache(_prePrepareMsg);
         m_config->timer()->restart();
-        auto nextProposalIndex = _prePrepareMsg->index();
-        if (!_prePrepareMsg->consensusProposal()->systemProposal() &&
-            nextProposalIndex < m_config->highWaterMark() && !_generatedFromNewView)
-        {
-            m_config->notifySealer(nextProposalIndex);
-            PBFT_LOG(DEBUG)
-                << LOG_DESC(
-                       "Receive valid non-system prePrepare proposal, notify to seal next proposal")
-                << LOG_KV("nextProposalIndex", nextProposalIndex);
-        }
         // broadcast PrepareMsg the packet
         broadcastPrepareMsg(_prePrepareMsg);
         PBFT_LOG(INFO) << LOG_DESC("handlePrePrepareMsg and broadcast prepare packet")
@@ -754,7 +762,6 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
                 {
                     PBFT_LOG(WARNING)
                         << LOG_DESC("verify proposal failed") << printPBFTMsgInfo(_prePrepareMsg);
-                    pbftEngine->resetSealedTxs(_prePrepareMsg);
                     pbftEngine->m_config->notifySealer(_prePrepareMsg->index(), true);
                     return;
                 }
@@ -1183,8 +1190,19 @@ void PBFTEngine::reHandlePrePrepareProposals(NewViewMsgInterface::Ptr _newViewRe
                 handlePrePrepareMsg(_prePrepare, true, true, false);
             });
     }
-    // re-notify the new leader to seal block
-    m_config->reNotifySealer(maxProposalIndex + 1);
+    if (prePrepareList.size() > 0)
+    {
+        // Note: in case of the reHandled proposals have system transactions, must wait to reseal
+        // until all reHandled proposal committed
+        m_config->setWaitResealUntil(maxProposalIndex);
+        PBFT_LOG(INFO) << LOG_DESC(
+                              "reHandlePrePrepareProposals and wait to reseal new proposal until ")
+                       << (maxProposalIndex);
+    }
+    else
+    {
+        m_config->reNotifySealer(maxProposalIndex + 1);
+    }
 }
 
 void PBFTEngine::finalizeConsensus(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
@@ -1192,9 +1210,9 @@ void PBFTEngine::finalizeConsensus(LedgerConfig::Ptr _ledgerConfig, bool _synced
     Guard l(m_mutex);
     // resetConfig after submit the block to ledger
     m_config->resetConfig(_ledgerConfig, _syncedBlock);
+    m_cacheProcessor->tryToApplyCommitQueue();
     // tried to commit the stable checkpoint
     m_cacheProcessor->removeConsensusedCache(m_config->view(), _ledgerConfig->blockNumber());
-    m_cacheProcessor->tryToApplyCommitQueue();
     m_cacheProcessor->tryToCommitStableCheckPoint();
     m_cacheProcessor->resetTimer();
     if (_syncedBlock)
@@ -1216,7 +1234,7 @@ bool PBFTEngine::handleCheckPointMsg(std::shared_ptr<PBFTMessageInterface> _chec
                         << m_config->printCurrentState();
         return false;
     }
-    if (m_config->committedProposal()->index() < m_config->syncingHighestNumber())
+    if (isSyncingHigher())
     {
         PBFT_LOG(INFO) << LOG_DESC(
                               "handleCheckPointMsg: reject the checkPoint for the node is "

--- a/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -105,6 +105,8 @@ protected:
     virtual bool handlePrePrepareMsg(std::shared_ptr<PBFTMessageInterface> _prePrepareMsg,
         bool _needVerifyProposal, bool _generatedFromNewView = false,
         bool _needCheckSignature = true);
+    virtual void resetSealedTxs(std::shared_ptr<PBFTMessageInterface> _prePrepareMsg);
+
     virtual CheckResult checkPrePrepareMsg(std::shared_ptr<PBFTMessageInterface> _prePrepareMsg);
     virtual CheckResult checkSignature(std::shared_ptr<PBFTBaseMessageInterface> _req);
     virtual bool checkProposalSignature(
@@ -147,16 +149,13 @@ protected:
     virtual void onProposalApplySuccess(
         PBFTProposalInterface::Ptr _proposal, PBFTProposalInterface::Ptr _executedProposal);
     virtual void onProposalApplyFailed(PBFTProposalInterface::Ptr _proposal);
-
-    virtual void resetSealedTxs(std::shared_ptr<PBFTMessageInterface> _prePrepareMsg);
-
     virtual void onLoadAndVerifyProposalSucc(PBFTProposalInterface::Ptr _proposal);
     virtual void triggerTimeout();
 
     void handleRecoverResponse(PBFTMessageInterface::Ptr _recoverResponse);
     void handleRecoverRequest(PBFTMessageInterface::Ptr _request);
     void sendRecoverResponse(bcos::crypto::NodeIDPtr _dstNode);
-
+    bool isSyncingHigher();
     /**
      * @brief Receive proposal requests from other nodes and reply to corresponding proposals
      *


### PR DESCRIPTION
1.  fix seal new block caused sync exception when reHandle the proposals with system transactions
2. check before PBFTConfig::resetConfig
3. fix checkPrePrepare