### PR TITLE
fix the first started node can't recover the view

### DIFF
--- a/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -606,11 +606,11 @@ ViewType PBFTCacheProcessor::tryToTriggerFastViewChange()
     ViewType viewToReach = 0;
     for (auto const& it : m_viewChangeCache)
     {
-        if (it.first <= m_config->toView())
+        auto view = it.first;
+        if (view <= m_config->toView())
         {
             continue;
         }
-        auto view = it.first;
         if (viewToReach == 0)
         {
             viewToReach = view;
@@ -653,8 +653,8 @@ ViewType PBFTCacheProcessor::tryToTriggerFastViewChange()
 
 bool PBFTCacheProcessor::checkPrecommitMsg(PBFTMessageInterface::Ptr _precommitMsg)
 {
-    // check the view
-    if (_precommitMsg->view() > m_config->view())
+    // check the view(the first started node no need to check the view)
+    if (m_config->startRecovered() && (_precommitMsg->view() > m_config->view()))
     {
         return false;
     }

--- a/bcos-pbft/pbft/config/PBFTConfig.h
+++ b/bcos-pbft/pbft/config/PBFTConfig.h
@@ -207,11 +207,16 @@ public:
         {
             return;
         }
+        if (m_startRecovered.load() == false)
+        {
+            m_startRecovered.store(true);
+        }
         // reset the timer when reach a new-view
         resetTimer();
         // update the changeCycle
         timer()->resetChangeCycle();
         setView(_view);
+        setToView(_view);
         m_timeoutState.store(false);
     }
     virtual void setUnSealedTxsSize(size_t _unsealedTxsSize)
@@ -339,6 +344,8 @@ public:
 
     virtual bool tryTriggerFastViewChange(IndexType _leaderIndex);
 
+    virtual bool startRecovered() const { return m_startRecovered; }
+
 protected:
     void updateQuorum() override;
     virtual void asyncNotifySealProposal(size_t _proposalIndex, size_t _proposalEndIndex,
@@ -400,6 +407,8 @@ protected:
     SharedMutex x_connectedNodeList;
 
     std::function<void()> m_fastViewChangeHandler;
+
+    std::atomic_bool m_startRecovered = {false};
 };
 }  // namespace consensus
 }  // namespace bcos


### PR DESCRIPTION
fix the first started node can't recover the view when no more than (2*f+1) nodes non-faulty with precommit proposals